### PR TITLE
dataLayerに利用するkeyの修正

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -93,8 +93,12 @@ const process = obj => {
     delta: obj.delta,
     valueRounded: Math.round(obj.name === 'CLS' ? obj.value * 1000 : obj.value),
     deltaRounded: Math.round(obj.name === 'CLS' ? obj.delta * 1000 : obj.delta),
-    attribution: obj.attribution ? JSON.stringify(obj.attribution) : '',
   };
+  if (obj.name === 'INP' && obj.attribution) {
+    cwvObj.inpEventTarget = obj.attribution.eventTarget ? obj.attribution.eventTarget : '';
+    cwvObj.inpEventType = obj.attribution.eventType ? obj.attribution.eventType : '';
+    cwvObj.inpLoadState = obj.attribution.loadState ? obj.attribution.loadState : '';
+  }
   log(cwvObj);
   if (data.namespace) {
     // If namespaced, add the measurement under the name of the measurement
@@ -284,25 +288,24 @@ scenarios:
     \ 'incorrect LCP object pushed to dataLayer').isEqualTo({\n      event: 'coreWebVitals',\n\
     \      webVitalsMeasurement: {\n        id: 'LCP',\n        name: 'LCP',\n   \
     \     value: 1.23,\n        delta: 1.55,\n        valueRounded: 1,\n        deltaRounded:\
-    \ 2,\n        attribution: ''\n      }\n    });\n    if (obj.webVitalsMeasurement.id\
-    \ === 'FID') assertThat(obj, 'incorrect FID object pushed to dataLayer').isEqualTo({\n\
-    \      event: 'coreWebVitals',\n      webVitalsMeasurement: {\n        id: 'FID',\n\
-    \        name: 'FID',\n        value: 1.23,\n        delta: 1.55,\n        valueRounded:\
-    \ 1,\n        deltaRounded: 2,\n        attribution: ''\n      }\n    });\n  \
-    \  if (obj.webVitalsMeasurement.id === 'CLS') assertThat(obj, 'incorrect CLS object\
-    \ pushed to dataLayer').isEqualTo({\n      event: 'coreWebVitals',\n      webVitalsMeasurement:\
-    \ {\n        id: 'CLS',\n        name: 'CLS',\n        value: 0.00123,\n     \
-    \   delta: 0.00155,\n        valueRounded: 1,\n        deltaRounded: 2,\n    \
-    \    attribution: ''\n      }\n    });\n  };\n});\n\nmock('injectScript', (url,\
+    \ 2\n      }\n    });\n    if (obj.webVitalsMeasurement.id === 'FID') assertThat(obj,\
+    \ 'incorrect FID object pushed to dataLayer').isEqualTo({\n      event: 'coreWebVitals',\n\
+    \      webVitalsMeasurement: {\n        id: 'FID',\n        name: 'FID',\n   \
+    \     value: 1.23,\n        delta: 1.55,\n        valueRounded: 1,\n        deltaRounded:\
+    \ 2\n      }\n    });\n    if (obj.webVitalsMeasurement.id === 'CLS') assertThat(obj,\
+    \ 'incorrect CLS object pushed to dataLayer').isEqualTo({\n      event: 'coreWebVitals',\n\
+    \      webVitalsMeasurement: {\n        id: 'CLS',\n        name: 'CLS',\n   \
+    \     value: 0.00123,\n        delta: 0.00155,\n        valueRounded: 1,\n   \
+    \     deltaRounded: 2\n      }\n    });\n  };\n});\n\nmock('injectScript', (url,\
     \ onsuccess, onfailure, id) => {\n  success = onsuccess;\n  failure = onfailure;\n\
     \  onsuccess();\n});\n\nmock('copyFromWindow', globalVar => {\n  assertThat(globalVar,\
     \ 'Incorrect global variable loaded from window').isEqualTo('webVitals');\n  return\
     \ {\n    onCLS: (cb) => { milestoneCount++; cb({name: 'CLS', id: 'CLS', value:\
-    \ 0.00123, delta: 0.00155, valueRounded: 1, deltaRounded: 2, attribution: ''});\
+    \ 0.00123, delta: 0.00155, valueRounded: 1, deltaRounded: 2, attribution: {}});\
     \ },\n    onLCP: (cb) => { milestoneCount++; cb({name: 'LCP', id: 'LCP', value:\
-    \ 1.23, delta: 1.55, valueRounded: 1, deltaRounded: 2, attribution: ''}); },\n\
+    \ 1.23, delta: 1.55, valueRounded: 1, deltaRounded: 2, attribution: {}}); },\n\
     \    onFID: (cb) => { milestoneCount++; cb({name: 'FID', id: 'FID', value: 1.23,\
-    \ delta: 1.55, valueRounded: 1, deltaRounded: 2, attribution: ''}); }\n  };\n\
+    \ delta: 1.55, valueRounded: 1, deltaRounded: 2, attribution: {}}); }\n  };\n\
     });\n \n// Call runCode to run the template's code.\nrunCode({});\n\n// Verify\
     \ that the tag finished successfully.\nassertApi('injectScript').wasCalledWith('https://unpkg.com/web-vitals@3/dist/web-vitals.attribution.iife.js',\
     \ success, failure, 'web-vitals');\nassertThat(milestoneCount, 'webVitals called\
@@ -314,29 +317,28 @@ scenarios:
     \        event: 'coreWebVitals',\n        webVitalsMeasurement: {\n          LCP:\
     \ {\n            id: 'LCP',\n            name: 'LCP',\n            value: 1.23,\n\
     \            delta: 1.55,\n            valueRounded: 1,\n            deltaRounded:\
-    \ 2,\n            attribution: ''\n          }\n        }\n      });\n      lcpPushed\
-    \ = true;\n    }\n    if (obj.webVitalsMeasurement.FID) {\n      assertThat(obj,\
-    \ 'incorrect FID object pushed to dataLayer').isEqualTo({\n        event: 'coreWebVitals',\n\
-    \        webVitalsMeasurement: {\n          FID: {\n            id: 'FID',\n \
-    \           name: 'FID',\n            value: 1.23,\n            delta: 1.55,\n\
-    \            valueRounded: 1,\n            deltaRounded: 2,\n            attribution:\
-    \ ''\n          }\n        }\n      });\n      fidPushed = true;\n    }\n    if\
-    \ (obj.webVitalsMeasurement.CLS) {\n      assertThat(obj, 'incorrect CLS object\
+    \ 2\n          }\n        }\n      });\n      lcpPushed = true;\n    }\n    if\
+    \ (obj.webVitalsMeasurement.FID) {\n      assertThat(obj, 'incorrect FID object\
     \ pushed to dataLayer').isEqualTo({\n        event: 'coreWebVitals',\n       \
-    \ webVitalsMeasurement: {\n          CLS: {\n            id: 'CLS',\n        \
-    \    name: 'CLS',\n            value: 0.00123,\n            delta: 0.00155,\n\
-    \            valueRounded: 1,\n            deltaRounded: 2,\n            attribution:\
-    \ ''\n          }\n        }\n      });\n      clsPushed = true;\n    }\n  };\n\
+    \ webVitalsMeasurement: {\n          FID: {\n            id: 'FID',\n        \
+    \    name: 'FID',\n            value: 1.23,\n            delta: 1.55,\n      \
+    \      valueRounded: 1,\n            deltaRounded: 2\n          }\n        }\n\
+    \      });\n      fidPushed = true;\n    }\n    if (obj.webVitalsMeasurement.CLS)\
+    \ {\n      assertThat(obj, 'incorrect CLS object pushed to dataLayer').isEqualTo({\n\
+    \        event: 'coreWebVitals',\n        webVitalsMeasurement: {\n          CLS:\
+    \ {\n            id: 'CLS',\n            name: 'CLS',\n            value: 0.00123,\n\
+    \            delta: 0.00155,\n            valueRounded: 1,\n            deltaRounded:\
+    \ 2\n          }\n        }\n      });\n      clsPushed = true;\n    }\n  };\n\
     });\n\nmock('injectScript', (url, onsuccess, onfailure, id) => {\n  success =\
     \ onsuccess;\n  failure = onfailure;\n  onsuccess();\n});\n\nmock('copyFromWindow',\
     \ globalVar => {\n  assertThat(globalVar, 'Incorrect global variable loaded from\
     \ window').isEqualTo('webVitals');\n  return {\n    onCLS: (cb) => { milestoneCount++;\
     \ cb({name: 'CLS', id: 'CLS', value: 0.00123, delta: 0.00155, valueRounded: 1,\
-    \ deltaRounded: 2, attribution: ''}); },\n    onLCP: (cb) => { milestoneCount++;\
+    \ deltaRounded: 2, attribution: {}}); },\n    onLCP: (cb) => { milestoneCount++;\
     \ cb({name: 'LCP', id: 'LCP', value: 1.23, delta: 1.55, valueRounded: 1, deltaRounded:\
-    \ 2, attribution: ''}); },\n    onFID: (cb) => { milestoneCount++; cb({name: 'FID',\
+    \ 2, attribution: {}}); },\n    onFID: (cb) => { milestoneCount++; cb({name: 'FID',\
     \ id: 'FID', value: 1.23, delta: 1.55, valueRounded: 1, deltaRounded: 2, attribution:\
-    \ ''}); }\n  };\n});\n \n// Call runCode to run the template's code.\nrunCode({namespace:\
+    \ {}}); }\n  };\n});\n \n// Call runCode to run the template's code.\nrunCode({namespace:\
     \ true});\n\n// Verify that the tag finished successfully.\nassertApi('injectScript').wasCalledWith('https://unpkg.com/web-vitals@3/dist/web-vitals.attribution.iife.js',\
     \ success, failure, 'web-vitals');\nassertThat(milestoneCount, 'webVitals called\
     \ incorrect number of times').isEqualTo(3);\nassertThat(lcpPushed, 'LCP object\
@@ -349,47 +351,45 @@ scenarios:
     \ 'incorrect LCP object pushed to dataLayer').isEqualTo({\n      event: 'coreWebVitals',\n\
     \      webVitalsMeasurement: {\n        id: 'LCP',\n        name: 'LCP',\n   \
     \     value: 1.23,\n        delta: 1.55,\n        valueRounded: 1,\n        deltaRounded:\
-    \ 2,\n        attribution: ''\n      }\n    });\n    if (obj.webVitalsMeasurement.id\
-    \ === 'FID') assertThat(obj, 'incorrect FID object pushed to dataLayer').isEqualTo({\n\
-    \      event: 'coreWebVitals',\n      webVitalsMeasurement: {\n        id: 'FID',\n\
-    \        name: 'FID',\n        value: 1.23,\n        delta: 1.55,\n        valueRounded:\
-    \ 1,\n        deltaRounded: 2,\n        attribution: ''\n      }\n    });\n  \
-    \  if (obj.webVitalsMeasurement.id === 'CLS') assertThat(obj, 'incorrect CLS object\
-    \ pushed to dataLayer').isEqualTo({\n      event: 'coreWebVitals',\n      webVitalsMeasurement:\
-    \ {\n        id: 'CLS',\n        name: 'CLS',\n        value: 0.00123,\n     \
-    \   delta: 0.00155,\n        valueRounded: 1,\n        deltaRounded: 2,\n    \
-    \    attribution: ''\n      }\n    });\n    if (obj.webVitalsMeasurement.id ===\
+    \ 2\n      }\n    });\n    if (obj.webVitalsMeasurement.id === 'FID') assertThat(obj,\
+    \ 'incorrect FID object pushed to dataLayer').isEqualTo({\n      event: 'coreWebVitals',\n\
+    \      webVitalsMeasurement: {\n        id: 'FID',\n        name: 'FID',\n   \
+    \     value: 1.23,\n        delta: 1.55,\n        valueRounded: 1,\n        deltaRounded:\
+    \ 2\n      }\n    });\n    if (obj.webVitalsMeasurement.id === 'CLS') assertThat(obj,\
+    \ 'incorrect CLS object pushed to dataLayer').isEqualTo({\n      event: 'coreWebVitals',\n\
+    \      webVitalsMeasurement: {\n        id: 'CLS',\n        name: 'CLS',\n   \
+    \     value: 0.00123,\n        delta: 0.00155,\n        valueRounded: 1,\n   \
+    \     deltaRounded: 2\n      }\n    });\n    if (obj.webVitalsMeasurement.id ===\
     \ 'FCP') assertThat(obj, 'incorrect FCP object pushed to dataLayer').isEqualTo({\n\
     \      event: 'coreWebVitals',\n      webVitalsMeasurement: {\n        id: 'FCP',\n\
     \        name: 'FCP',\n        value: 123.4,\n        delta: 123.5,\n        valueRounded:\
-    \ 123,\n        deltaRounded: 124,\n        attribution: ''\n      }\n    });\n\
-    \    if (obj.webVitalsMeasurement.id === 'INP') assertThat(obj, 'incorrect INP\
-    \ object pushed to dataLayer').isEqualTo({\n      event: 'coreWebVitals',\n  \
-    \    webVitalsMeasurement: {\n        id: 'INP',\n        name: 'INP',\n     \
-    \   value: 40,\n        delta: 40,\n        valueRounded: 40,\n        deltaRounded:\
-    \ 40,\n        attribution: ''\n      }\n    });\n    if (obj.webVitalsMeasurement.id\
+    \ 123,\n        deltaRounded: 124\n      }\n    });\n    if (obj.webVitalsMeasurement.id\
+    \ === 'INP') assertThat(obj, 'incorrect INP object pushed to dataLayer').isEqualTo({\n\
+    \      event: 'coreWebVitals',\n      webVitalsMeasurement: {\n        id: 'INP',\n\
+    \        name: 'INP',\n        value: 40,\n        delta: 40,\n        valueRounded:\
+    \ 40,\n        deltaRounded: 40,\n        inpEventTarget: '',\n        inpEventType:\
+    \ '',\n        inpLoadState: ''\n      }\n    });\n    if (obj.webVitalsMeasurement.id\
     \ === 'TTFB') assertThat(obj, 'incorrect TTFB object pushed to dataLayer').isEqualTo({\n\
     \      event: 'coreWebVitals',\n      webVitalsMeasurement: {\n        id: 'TTFB',\n\
     \        name: 'TTFB',\n        value: 123.4,\n        delta: 123.5,\n       \
-    \ valueRounded: 123,\n        deltaRounded: 124,\n        attribution: ''\n  \
-    \    }\n    });\n  };\n});\n\nmock('injectScript', (url, onsuccess, onfailure,\
-    \ id) => {\n  success = onsuccess;\n  failure = onfailure;\n  onsuccess();\n});\n\
-    \nmock('copyFromWindow', globalVar => {\n  assertThat(globalVar, 'Incorrect global\
-    \ variable loaded from window').isEqualTo('webVitals');\n  return {\n    onCLS:\
-    \ (cb) => { milestoneCount++; cb({name: 'CLS', id: 'CLS', value: 0.00123, delta:\
-    \ 0.00155, valueRounded: 1, deltaRounded: 2, attribution: ''}); },\n    onLCP:\
-    \ (cb) => { milestoneCount++; cb({name: 'LCP', id: 'LCP', value: 1.23, delta:\
-    \ 1.55, valueRounded: 1, deltaRounded: 2, attribution: ''}); },\n    onFID: (cb)\
-    \ => { milestoneCount++; cb({name: 'FID', id: 'FID', value: 1.23, delta: 1.55,\
-    \ valueRounded: 1, deltaRounded: 2, attribution: ''}); },\n    onFCP: (cb) =>\
-    \ { milestoneCount++; cb({name: 'FCP', id: 'FCP', value: 123.4, delta: 123.5,\
-    \ valueRounded: 123, deltaRounded: 124, attribution: ''}); },\n    onINP: (cb)\
+    \ valueRounded: 123,\n        deltaRounded: 124\n      }\n    });\n  };\n});\n\
+    \nmock('injectScript', (url, onsuccess, onfailure, id) => {\n  success = onsuccess;\n\
+    \  failure = onfailure;\n  onsuccess();\n});\n\nmock('copyFromWindow', globalVar\
+    \ => {\n  assertThat(globalVar, 'Incorrect global variable loaded from window').isEqualTo('webVitals');\n\
+    \  return {\n    onCLS: (cb) => { milestoneCount++; cb({name: 'CLS', id: 'CLS',\
+    \ value: 0.00123, delta: 0.00155, valueRounded: 1, deltaRounded: 2, attribution:\
+    \ {}}); },\n    onLCP: (cb) => { milestoneCount++; cb({name: 'LCP', id: 'LCP',\
+    \ value: 1.23, delta: 1.55, valueRounded: 1, deltaRounded: 2}); },\n    onFID:\
+    \ (cb) => { milestoneCount++; cb({name: 'FID', id: 'FID', value: 1.23, delta:\
+    \ 1.55, valueRounded: 1, deltaRounded: 2, attribution: {}}); },\n    onFCP: (cb)\
+    \ => { milestoneCount++; cb({name: 'FCP', id: 'FCP', value: 123.4, delta: 123.5,\
+    \ valueRounded: 123, deltaRounded: 124, attribution: {}}); },\n    onINP: (cb)\
     \ => { milestoneCount++; cb({name: 'INP', id: 'INP', value: 40, delta: 40, valueRounded:\
-    \ 40, deltaRounded: 40}); },\n    onTTFB: (cb) => { milestoneCount++; cb({name:\
-    \ 'TTFB', id: 'TTFB', value: 123.4, delta: 123.5, valueRounded: 123, deltaRounded:\
-    \ 124, attribution: ''}); }\n  };\n});\n \n// Call runCode to run the template's\
-    \ code.\nrunCode({allMetrics: true});\n\n// Verify that the tag finished successfully.\n\
-    assertApi('injectScript').wasCalledWith('https://unpkg.com/web-vitals@3/dist/web-vitals.attribution.iife.js',\
+    \ 40, deltaRounded: 40, attribution: {inpEventTarget: '', inpEventType: '', inpLoadState:\
+    \ ''}}); },\n    onTTFB: (cb) => { milestoneCount++; cb({name: 'TTFB', id: 'TTFB',\
+    \ value: 123.4, delta: 123.5, valueRounded: 123, deltaRounded: 124, attribution:\
+    \ {}}); }\n  };\n});\n \n// Call runCode to run the template's code.\nrunCode({allMetrics:\
+    \ true});\n\n// Verify that the tag finished successfully.\nassertApi('injectScript').wasCalledWith('https://unpkg.com/web-vitals@3/dist/web-vitals.attribution.iife.js',\
     \ success, failure, 'web-vitals');\nassertThat(milestoneCount, 'webVitals called\
     \ incorrect number of times').isEqualTo(6);\nassertApi('gtmOnSuccess').wasCalled();"
 setup: ''


### PR DESCRIPTION
イベント値の上限文字数が100文字までなので、計測したいINPのattributionのみGAに送信するように改修。
送信するようにしたkeyは以下の3つ。
- inpEventTarget
- inpEventType
- inpLoadState